### PR TITLE
Do not use symlink 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,15 @@ jobs:
         
     - uses: astral-sh/setup-uv@v5
       with:
-        version: "0.5.14"
+      version: "0.5.14"
     - run: uv build
+    - name: Commit uv.lock
+      run: |
+        git config --local user.email "actions@users.noreply.github.com"
+        git config --local user.name "github-actions"
+        git add uv.lock
+        git commit -m "chore: Update uv.lock" || echo "No changes to commit"
+        git push
   
     # https://github.com/pypa/gh-action-pypi-publish
     - name: Publish package distributions to PyPI

--- a/src/stepit/stepit.py
+++ b/src/stepit/stepit.py
@@ -3,9 +3,7 @@ import hashlib
 import inspect
 import logging
 import os
-import pathlib
 import pickle
-import shutil
 import time
 
 # Set up logging
@@ -42,12 +40,17 @@ def default_serialize(result, filename):
 
 
 def default_deserialize(filename):
-    """Deserialize using pickle, considering that the file might be a symlink."""
-    if pathlib.Path(filename).is_symlink():
-        filename = os.readlink(filename)
+    """Deserialize using pickle."""
 
-    with open(filename, "rb") as f:
-        return pickle.load(f)
+    try:
+        with open(filename, "rb") as f:
+            return pickle.load(f)
+    except Exception:
+        with open(filename, "r") as f:
+            real_file = f.readline().strip()
+            filename = real_file
+        with open(filename, "rb") as f:
+            return pickle.load(f)
 
 
 def format_size(size):
@@ -134,15 +137,12 @@ def _compute_recursive_hash(func, seen=None):
 
 
 def create_symlink(symlink_path, target_file):
-    """Creates a symbolic link, handling cross-platform differences."""
+    """Creates a plain text file containing the target file's path."""
     try:
-        if os.path.exists(symlink_path) or os.path.islink(symlink_path):
-            os.remove(symlink_path)  # Remove old symlink if it exists
-
-        os.symlink(target_file, symlink_path)  # Create new symlink
-
-    except OSError:
-        shutil.copy2(target_file, symlink_path)  # Fallback: Copy the file
+        with open(symlink_path, "w") as f:
+            f.write(target_file)
+    except OSError as e:
+        logger.error(f"Failed to create text file: {e}")
 
 
 def stepit(
@@ -204,9 +204,18 @@ def stepit(
 
             current = wrapper.__stepit_config__
             cache_file = os.path.join(
-                current["cache_dir"], f"{current['key']}_{filename_hash}"
+                current["cache_dir"],
+                f"{current['key']}_{filename_hash}_{time.strftime('%Y%m%d%H%M%S')}",
+            )
+            cache_file = os.path.join(
+                current["cache_dir"],
+                f"{current['key']}_{filename_hash}",
             )
             key_file = os.path.join(current["cache_dir"], f"{current['key']}")
+
+            # matching_files = glob.glob(f"{prefix}*")
+
+            #     if os.path.commonprefix([os.path.abspath(path), os.path.abspath(prefix)]) == os.path.abspath(prefix):
 
             if os.path.exists(cache_file):
                 try:

--- a/src/stepit/stepit.py
+++ b/src/stepit/stepit.py
@@ -204,23 +204,12 @@ def stepit(
         def wrapper(*args, **kwargs):
             args_hash = _compute_args_hash(func, args, kwargs)
             source_hash = _compute_source_hash(func)
-            composite = f"{source_hash}:{args_hash}"
-            filename_hash = hashlib.md5(composite.encode("utf-8")).hexdigest()
 
             current = wrapper.__stepit_config__
             cache_file = os.path.join(
-                current["cache_dir"],
-                f"{current['key']}_{filename_hash}_{time.strftime('%Y%m%d%H%M%S')}",
-            )
-            cache_file = os.path.join(
-                current["cache_dir"],
-                f"{current['key']}_{filename_hash}",
+                current["cache_dir"], f"{current['key']}_{source_hash}_{args_hash}"
             )
             key_file = os.path.join(current["cache_dir"], f"{current['key']}")
-
-            # matching_files = glob.glob(f"{prefix}*")
-
-            #     if os.path.commonprefix([os.path.abspath(path), os.path.abspath(prefix)]) == os.path.abspath(prefix):
 
             if os.path.exists(cache_file):
                 try:
@@ -233,6 +222,7 @@ def stepit(
 
                     create_symlink(key_file, cache_file)
                     return current["deserialize"](cache_file)
+
                 except Exception as e:
                     logger.warning(
                         f"⚠️ stepit '{config['key']}': Could not load cache. "

--- a/tests/test_stepit.py
+++ b/tests/test_stepit.py
@@ -26,19 +26,23 @@ def test_stepit_defaults(caplog: pytest.LogCaptureFixture):
     start_time = time.time()
     a(5)
     elapsed_time = time.time() - start_time
-    assert "Starting execution" in caplog.text
-    assert "Successfully completed and cached" in caplog.text
-    assert elapsed_time >= 5
-    assert default_deserialize(f"{cache_dir}/a") == 7
+    assert "Starting execution" in caplog.text, "fail logging starting execution"
+    assert "Successfully completed and cached" in caplog.text, "fail logging success"
+    assert elapsed_time >= 5, "did not wait"
+    assert default_deserialize(f"{cache_dir}/a") == 7, "could not read current"
     caplog.clear()
 
     start_time = time.time()
     a(5)
     elapsed_time = time.time() - start_time
-    assert "is up-to-date. Using cached result" in caplog.text
-    assert "Starting execution" not in caplog.text
-    assert "Successfully completed and cached" not in caplog.text
-    assert elapsed_time < 2
+    assert "is up-to-date. Using cached result" in caplog.text, (
+        "failed logging use cache"
+    )
+    assert "Starting execution" not in caplog.text, "should not log start"
+    assert "Successfully completed and cached" not in caplog.text, (
+        "should not log success"
+    )
+    assert elapsed_time < 2, "should be fast"
 
 
 def test_stepit_change_source(caplog: pytest.LogCaptureFixture):
@@ -309,4 +313,3 @@ def test_formatters():
     assert format_time(60 * 4) == "4 minutes"
     assert format_time(60 * 60) == "1 hours"
     assert format_time(60 * 60 * 24) == "1 days"
-    

--- a/uv.lock
+++ b/uv.lock
@@ -770,7 +770,7 @@ wheels = [
 
 [[package]]
 name = "stepit"
-version = "0.3.1"
+version = "0.4.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Do not use a symlink for the pointer to the current cache. Instead, use a simple plain text file containing the path. Symlinks can be problematic as they behave differently across platforms.